### PR TITLE
refactor: centralize hardcoded constants into src/config.py

### DIFF
--- a/scripts/check_cap_proxy_bias.py
+++ b/scripts/check_cap_proxy_bias.py
@@ -30,7 +30,7 @@ import yfinance as yf
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from src.config import CANDIDATE_POOL_TICKERS, DATA_DIR, DATA_START_DATE
+from src.config import CANDIDATE_POOL_TICKERS, DATA_DIR, DATA_START_DATE, MIRROR_TOP_N
 from src.data.storage import load_parquet
 from src.data.universe import get_members_at, load_shares_outstanding, rank_by_cap_proxy
 
@@ -38,7 +38,6 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s  %(levelname)-8s  %(
 logger = logging.getLogger(__name__)
 
 RESEARCH_DIR = DATA_DIR / "research"
-TOP_N = 20
 
 
 def fetch_split_adjusted_closes(tickers: list[str]) -> pd.DataFrame:
@@ -92,8 +91,8 @@ def main() -> int:
         members = get_members_at(dt)
         rank_adj = rank_by_cap_proxy(adjusted, shares, dt)
         rank_raw = rank_by_cap_proxy(split_only, shares, dt)
-        top_adj = [t for t in rank_adj.index if t in members][:TOP_N]
-        top_raw = [t for t in rank_raw.index if t in members][:TOP_N]
+        top_adj = [t for t in rank_adj.index if t in members][:MIRROR_TOP_N]
+        top_raw = [t for t in rank_raw.index if t in members][:MIRROR_TOP_N]
 
         only_adj = sorted(set(top_adj) - set(top_raw))
         only_raw = sorted(set(top_raw) - set(top_adj))
@@ -108,7 +107,7 @@ def main() -> int:
             })
 
     summary = {
-        "top_n": TOP_N,
+        "top_n": MIRROR_TOP_N,
         "n_months": len(dates),
         "n_months_with_membership_diff": n_diff_months,
         "pct_months_differing": round(n_diff_months / len(dates) * 100, 1),
@@ -124,7 +123,7 @@ def main() -> int:
     logger.info(
         "Top-%d membership differs in %d of %d months (%.1f%%); "
         "%d name-month swaps total. Written to %s",
-        TOP_N,
+        MIRROR_TOP_N,
         n_diff_months,
         len(dates),
         summary["pct_months_differing"],

--- a/scripts/export_frontend_data.py
+++ b/scripts/export_frontend_data.py
@@ -28,6 +28,7 @@ from src.config import (
     BENCHMARK_TICKER,
     CANDIDATE_POOL_TICKERS,
     DATA_DIR,
+    DEFAULT_RISK_FREE_RATE,
     INCEPTION_DATE,
     TRADING_DAYS_PER_YEAR,
 )
@@ -193,8 +194,9 @@ def load_all_data() -> tuple[pd.DataFrame, pd.Series]:
 
 # ^IRX (13-week T-bill) is fetched but wasn't wired into Sharpe/Sortino/Jensen
 # alpha — every headline used a static 4% instead of the realized rate, a
-# ~15% swing on Sharpe over a period whose actual average was ~1.7%.
-_FALLBACK_RISK_FREE_RATE = 0.04
+# ~15% swing on Sharpe over a period whose actual average was ~1.7%. The
+# static fallback lives in src.config as the single source of truth.
+_FALLBACK_RISK_FREE_RATE = DEFAULT_RISK_FREE_RATE
 
 
 def realized_risk_free_rate(start: pd.Timestamp, end: pd.Timestamp) -> float:
@@ -458,17 +460,17 @@ def export_performance_nav(
     return _write_json(payload, "performance_nav.json")
 
 
-def _compute_extra_metrics(
-    nav: pd.Series,
-    benchmark_nav: pd.Series | None = None,
-) -> dict:
+def _compute_extra_metrics(nav: pd.Series) -> dict:
     """Compute additional daily-return metrics not in compute_performance_metrics.
 
-    Returns dict with keys: information_ratio, best_day, worst_day,
-    win_rate, avg_daily_return. Deliberately does NOT return "alpha" or
-    "beta" — compute_performance_metrics already provides Jensen's alpha
-    and regression beta, and overriding alpha with annualised mean excess
-    (as this function once did) silently changed its definition.
+    Returns dict with keys: best_day, worst_day, win_rate, avg_daily_return.
+    Deliberately does NOT return "information_ratio", "alpha", or "beta" —
+    compute_performance_metrics already provides all three (its information
+    ratio is CAGR-excess over annualised tracking error, its alpha is Jensen's
+    alpha, its beta the regression beta). Recomputing any of them here with a
+    different formula — as this function once did for alpha, and did for the
+    information ratio (annualised mean daily excess / its std) — silently
+    overrode the canonical definition via the caller's dict ``update``.
     """
     daily_returns = nav.pct_change().dropna()
 
@@ -477,21 +479,7 @@ def _compute_extra_metrics(
     win_rate = float((daily_returns > 0).mean()) if len(daily_returns) > 0 else 0.0
     avg_daily_return = float(daily_returns.mean()) if len(daily_returns) > 0 else 0.0
 
-    information_ratio = 0.0
-
-    if benchmark_nav is not None:
-        bench_returns = benchmark_nav.pct_change().dropna()
-        # Align on common index
-        common = daily_returns.index.intersection(bench_returns.index)
-        if len(common) > 10:
-            excess = daily_returns.loc[common] - bench_returns.loc[common]
-            excess_mean = float(excess.mean())
-            excess_std = float(excess.std())
-            if excess_std > 0:
-                information_ratio = (excess_mean / excess_std) * (252 ** 0.5)
-
     return {
-        "information_ratio": round(information_ratio, 6),
         "best_day": round(best_day, 6),
         "worst_day": round(worst_day, 6),
         "win_rate": round(win_rate, 6),
@@ -556,9 +544,9 @@ def export_performance_metrics(
     )
 
     # Enrich with extra daily-return metrics
-    bench_metrics.update(_compute_extra_metrics(benchmark_nav, None))
-    mirror_metrics.update(_compute_extra_metrics(mirror_nav, benchmark_nav))
-    equal_metrics.update(_compute_extra_metrics(equal_nav, benchmark_nav))
+    bench_metrics.update(_compute_extra_metrics(benchmark_nav))
+    mirror_metrics.update(_compute_extra_metrics(mirror_nav))
+    equal_metrics.update(_compute_extra_metrics(equal_nav))
 
     bench_metrics["window"] = _window_info(benchmark_nav)
     mirror_metrics["window"] = _window_info(mirror_nav)
@@ -577,7 +565,7 @@ def export_performance_metrics(
         alpha_metrics = compute_performance_metrics(
             alpha_nav, benchmark_nav, risk_free_rate=risk_free_rate
         )
-        alpha_metrics.update(_compute_extra_metrics(alpha_nav, benchmark_nav))
+        alpha_metrics.update(_compute_extra_metrics(alpha_nav))
         alpha_metrics["window"] = _window_info(alpha_nav)
         alpha_metrics.update(extras.get("spn_alpha", {}))
         payload["spn_alpha"] = _clean_dict(alpha_metrics)

--- a/scripts/run_holdout.py
+++ b/scripts/run_holdout.py
@@ -39,10 +39,12 @@ from src.backtest.engine import walk_forward_backtest
 from src.backtest.metrics import deflated_sharpe
 from src.config import (
     DATA_DIR,
+    DEV_END,
     HOLDOUT_START,
     INCEPTION_DATE,
     SPN_MAX_STOCKS,
     TEST_WINDOW_DAYS,
+    TRADING_DAYS_PER_YEAR,
     TRAIN_WINDOW_DAYS,
 )
 from src.data.storage import load_parquet
@@ -98,7 +100,7 @@ def _dev_deflated_sharpe(winner_dev_returns: pd.Series) -> tuple[float, int, flo
     n = len(trials)
     sharpe_std = float(np.std(sharpes, ddof=1)) if len(sharpes) > 1 else 0.0
     # Convert annualised-Sharpe spread to per-period for the PSR benchmark.
-    per_period_std = sharpe_std / np.sqrt(252)
+    per_period_std = sharpe_std / np.sqrt(TRADING_DAYS_PER_YEAR)
     dsr = deflated_sharpe(winner_dev_returns, n_trials=n, sharpe_std=per_period_std)
     return dsr, n, sharpe_std
 
@@ -162,7 +164,7 @@ def main() -> int:
     )
 
     # Deflated Sharpe on the dev portion (multiple-testing disclosure).
-    dev_returns = nav[nav.index <= pd.Timestamp("2023-12-31")].pct_change().dropna()
+    dev_returns = nav[nav.index <= pd.Timestamp(DEV_END)].pct_change().dropna()
     dsr, n_trials, sharpe_std = _dev_deflated_sharpe(dev_returns)
 
     # Score on the holdout window only.

--- a/src/config.py
+++ b/src/config.py
@@ -90,6 +90,7 @@ SLIPPAGE_BPS = 2                    # 2 basis points slippage assumption
 UNIVERSE_LOOKBACK_DAYS = 63         # Trailing smoothing window for cap-proxy ranking
 UNIVERSE_MIN_OBS = 20               # Min non-NaN days required to rank a ticker
 MIRROR_REBALANCE_FREQ = "M"         # Mirror/Equal rebalance at month-end (period freq)
+MIRROR_TOP_N = 20                   # Mirror/Equal universe size (top-N by cap proxy)
 
 # ──────────────────────────────────────────────
 # Backtesting
@@ -97,6 +98,9 @@ MIRROR_REBALANCE_FREQ = "M"         # Mirror/Equal rebalance at month-end (perio
 TRAIN_WINDOW_DAYS = 756             # ~3 years of trading days
 TEST_WINDOW_DAYS = 21               # ~1 month of trading days
 TRADING_DAYS_PER_YEAR = 252
+# Static fallback risk-free rate (annual, decimal). Live code prefers the
+# realized ^IRX average; this is the single source for the static default.
+DEFAULT_RISK_FREE_RATE = 0.04
 
 # ──────────────────────────────────────────────
 # SP-N Alpha bounds

--- a/src/features/technical.py
+++ b/src/features/technical.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
+from src.config import TRADING_DAYS_PER_YEAR
+
 
 def compute_momentum(
     prices: pd.DataFrame,
@@ -50,7 +52,7 @@ def compute_realized_vol(
         DataFrame of annualised volatility per ticker.
     """
     daily_returns = prices.pct_change()
-    return daily_returns.rolling(window).std() * np.sqrt(252)
+    return daily_returns.rolling(window).std() * np.sqrt(TRADING_DAYS_PER_YEAR)
 
 
 def compute_rsi(

--- a/src/optimizer/ensemble.py
+++ b/src/optimizer/ensemble.py
@@ -13,7 +13,13 @@ import logging
 import pandas as pd
 from pypfopt import EfficientFrontier, risk_models
 
-from src.config import MAX_POSITION_WEIGHT, MIN_POSITION_WEIGHT
+from src.config import (
+    DEFAULT_RISK_FREE_RATE,
+    LGBM_FORWARD_DAYS,
+    MAX_POSITION_WEIGHT,
+    MIN_POSITION_WEIGHT,
+    TRADING_DAYS_PER_YEAR,
+)
 from src.optimizer.constraints import prune_and_renormalize
 from src.optimizer.hrp import hrp_weights
 
@@ -40,8 +46,8 @@ def _factor_mvo_weights(
     try:
         mu = predicted_returns.reindex(tickers, fill_value=0.0)
 
-        # Annualise the 21-day predicted returns
-        mu_annual = mu * (252 / 21)
+        # Annualise the LGBM_FORWARD_DAYS-horizon predicted returns
+        mu_annual = mu * (TRADING_DAYS_PER_YEAR / LGBM_FORWARD_DAYS)
 
         cov = risk_models.CovarianceShrinkage(train_prices).ledoit_wolf()
 
@@ -50,7 +56,7 @@ def _factor_mvo_weights(
             cov,
             weight_bounds=(MIN_POSITION_WEIGHT, MAX_POSITION_WEIGHT),
         )
-        ef.max_sharpe(risk_free_rate=0.04)
+        ef.max_sharpe(risk_free_rate=DEFAULT_RISK_FREE_RATE)
         raw = ef.clean_weights()
         w = pd.Series(raw, dtype=float)
         total = w.sum()

--- a/src/strategies/dynamic_alpha.py
+++ b/src/strategies/dynamic_alpha.py
@@ -79,7 +79,7 @@ def _momentum_tilt_engine(
     equal base by ``1 + clip(score)`` so winners are overweighted and losers
     underweighted without going short; then bounds are enforced.
     """
-    lookback = min(len(prices) - 1, 252)
+    lookback = min(len(prices) - 1, TRADING_DAYS_PER_YEAR)
     skip = 21
     if lookback <= skip + 5:
         return _equal_engine(prices)

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import pandas as pd
 
+from src.config import TRADING_DAYS_PER_YEAR
+
 
 def add_cash_column(
     prices: pd.DataFrame,
@@ -21,7 +23,7 @@ def add_cash_column(
     Returns:
         Copy of *prices* with an additional ``CASH`` column.
     """
-    daily_rf = (1 + risk_free_rate) ** (1 / 252) - 1
+    daily_rf = (1 + risk_free_rate) ** (1 / TRADING_DAYS_PER_YEAR) - 1
 
     # Build a compounding cash price series starting at 100
     n = len(prices)


### PR DESCRIPTION
## Summary

Enforces the CLAUDE.md rule that `src/config.py` is the single source of truth for all constants. An audit found the same literals duplicated across `src/` and `scripts/`; each is now replaced with an import of the existing (or newly added) config constant. **Pure refactor** — verified numerically inert against a fixed dataset.

## Config additions
| Constant | Value | Placed near |
|---|---|---|
| `MIRROR_TOP_N` | `20` | `MIRROR_REBALANCE_FREQ` |
| `DEFAULT_RISK_FREE_RATE` | `0.04` | Backtesting section |

## Substitutions (each now imports the config constant)
- **`run_holdout.py`** — `np.sqrt(252)` → `TRADING_DAYS_PER_YEAR`; the `"2023-12-31"` dev-split literal → `DEV_END` (`pd.Timestamp(DEV_END)` is byte-for-byte identical to the old string).
- **`export_frontend_data.py`** — `_FALLBACK_RISK_FREE_RATE` now sourced from `DEFAULT_RISK_FREE_RATE`.
- **`dynamic_alpha.py`** — momentum lookback cap `252` → `TRADING_DAYS_PER_YEAR` (the `min(len(prices)-1, …)` bounds guard is preserved; the literal instruction to replace the whole `min(...)` would have removed the guard and index-errored on short panels).
- **`technical.py`** — realized-vol annualisation `np.sqrt(252)` → `np.sqrt(TRADING_DAYS_PER_YEAR)`.
- **`helpers.py`** — daily risk-free compounding `1/252` → `1/TRADING_DAYS_PER_YEAR`.
- **`ensemble.py`** — `252/21` → `TRADING_DAYS_PER_YEAR / LGBM_FORWARD_DAYS`; `max_sharpe(risk_free_rate=0.04)` → `DEFAULT_RISK_FREE_RATE`.
- **`check_cap_proxy_bias.py`** — local `TOP_N = 20` → config `MIRROR_TOP_N`.

## De-duplication: Information Ratio (the one non-inert change)
`_compute_extra_metrics` recomputed `information_ratio` with an **arithmetic** formula (`mean_daily_excess / std × √252`) that **overrode** the **canonical** CAGR-excess / tracking-error definition already returned by `compute_performance_metrics` (via `dict.update`). This is the *same* silent-definition-override the function's own docstring documents having fixed for `alpha`/`beta`. The duplicate (and its now-unused `benchmark_nav` param) is dropped, so the canonical IR flows through.

**Effect on `performance_metrics.json`** (measured before/after on one fixed dataset):

| series | before (arithmetic) | after (canonical) |
|---|---|---|
| sp20_mirror | 0.5039 | 0.4993 |
| sp20_equal | 0.3912 | 0.4368 |
| spn_alpha | 0.6043 | 0.6258 |
| sp500 | 0.0 | key removed → frontend `?? 0` (same display) |

No other field changes. `meta.json` (headline + research blocks — every landing/proof number) is **byte-identical**.

## Verification
- `ruff check` ✅ · `mypy src/` ✅ (33 files) · `pytest tests/ -q` ✅ (**114 passed**, 2 slow deselected)
- Ran `export_frontend_data.py` on a fixed dataset before and after: confirmed the **only** JSON delta is `information_ratio` above; `meta.json` unchanged.

## Note on the committed JSON
The export was **not** re-committed. The local parquets are a day behind the CI-generated committed JSON, so a wholesale regenerate would mix a day of market-data drift into the diff. The committed `performance_metrics.json` will pick up the corrected canonical IR on the next scheduled **daily update** run — no manual regeneration needed.

## Out of scope (left as-is)
Function-signature default `risk_free_rate: float = 0.04` in `metrics.py`, `concentration.py`, and `helpers.py` (kept literal to avoid a broader signature change); other `252`/`top_n=20` literals in `export_frontend_data.py` not flagged by the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)