### PR TITLE
Phase 12 polish: accessibility & responsive gaps

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -221,6 +221,13 @@ body {
   animation: rotateGear 4s linear infinite;
 }
 
+/* Per-route enter transition (applied by app/template.tsx). Additive
+   only: resting opacity is 1, so the page is visible even if this never
+   plays. Neutralised by the reduced-motion block below. */
+.page-enter {
+  animation: fadeInUp 0.35s ease-out;
+}
+
 /* ============================================================
    Utility Classes -- Cards & Surfaces
    ============================================================ */
@@ -284,4 +291,53 @@ body {
 
 .accent-border-indigo {
   border-color: rgba(99, 102, 241, 0.3);
+}
+
+/* ============================================================
+   Focus Visibility -- keyboard operability
+   The machine power switch is an SVG <g> made focusable in
+   FlipSwitch.tsx; give keyboard users a visible focus ring.
+   ============================================================ */
+
+#power-switch:focus {
+  outline: none;
+}
+
+#power-switch:focus-visible {
+  outline: 2px solid var(--color-accent-primary);
+  outline-offset: 4px;
+  border-radius: 8px;
+}
+
+/* ============================================================
+   Reduced Motion
+   Respect the user's OS-level "reduce motion" preference:
+   neutralise the CSS keyframe animations (wire electricity,
+   glow/breathe/button pulses, shimmer, float, gear) and collapse
+   transition durations so nothing autoplays or drifts.
+   ============================================================ */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .wire-active,
+  .glow-pulse,
+  .breathe-glow,
+  .button-pulse,
+  .float-animation,
+  .rotate-gear,
+  .shimmer,
+  .page-enter {
+    animation: none !important;
+  }
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -31,6 +31,15 @@ const geistMono = Geist_Mono({
    ────────────────────────────────────────────────────────────── */
 
 export const metadata: Metadata = {
+  // Resolves relative asset URLs (e.g. the generated opengraph-image) to
+  // absolute ones for crawlers. Uses the Vercel deployment URL in prod and
+  // falls back to localhost in dev, so no domain is hardcoded.
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL ??
+      (process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : "http://localhost:3000"),
+  ),
   title: "S&P Index Lab",
   description:
     "Proving the S&P 500 is driven by ~20 stocks. An interactive analytics platform that deconstructs index concentration, builds point-in-time mirror indices, and compares four portfolios side by side under a pre-registered holdout.",

--- a/frontend/app/opengraph-image.tsx
+++ b/frontend/app/opengraph-image.tsx
@@ -1,0 +1,118 @@
+import { ImageResponse } from "next/og";
+
+/* ================================================================
+   opengraph-image -- 1200×630 social card
+   Generated at build time via next/og (Satori). Next.js auto-injects
+   the resulting og:image / twitter:image meta tags from this file
+   convention, so no manual metadata.openGraph.images entry is needed
+   (adding one would duplicate the tag). Kept qualitative so it never
+   contradicts the daily-refreshed numbers.
+   ================================================================ */
+
+export const alt =
+  "S&P Index Lab — the S&P 500 is effectively a ~20-stock index";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "80px",
+          backgroundColor: "#0A0A0F",
+          backgroundImage:
+            "radial-gradient(ellipse 70% 60% at 50% 40%, rgba(0,212,170,0.10) 0%, transparent 70%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        {/* Eyebrow */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            color: "#00D4AA",
+            fontSize: 26,
+            fontWeight: 700,
+            letterSpacing: "0.28em",
+            textTransform: "uppercase",
+          }}
+        >
+          S&P Index Lab
+        </div>
+
+        {/* Headline */}
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div
+            style={{
+              display: "flex",
+              color: "#F0F0F0",
+              fontSize: 76,
+              fontWeight: 700,
+              lineHeight: 1.1,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            The S&P 500 is effectively
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 76,
+              fontWeight: 700,
+              lineHeight: 1.1,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            <span style={{ color: "#F0F0F0" }}>a&nbsp;</span>
+            <span style={{ color: "#00D4AA" }}>~20-stock&nbsp;</span>
+            <span style={{ color: "#F0F0F0" }}>index.</span>
+          </div>
+        </div>
+
+        {/* Stat chips */}
+        <div style={{ display: "flex", alignItems: "center" }}>
+          {[
+            { label: "R-squared ~95%", accent: "#00D4AA" },
+            { label: "20 stocks", accent: "#FFD700" },
+            { label: "Point-in-time, net of costs", accent: "#6366F1" },
+          ].map((chip) => (
+            <div
+              key={chip.label}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                marginRight: 20,
+                padding: "12px 24px",
+                borderRadius: 999,
+                border: "1px solid #2A2A35",
+                backgroundColor: "#111118",
+                color: "#F0F0F0",
+                fontSize: 28,
+                fontWeight: 600,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  width: 12,
+                  height: 12,
+                  borderRadius: 999,
+                  marginRight: 14,
+                  backgroundColor: chip.accent,
+                }}
+              />
+              {chip.label}
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/frontend/app/template.tsx
+++ b/frontend/app/template.tsx
@@ -1,0 +1,22 @@
+/* ================================================================
+   Route template -- subtle enter transition between pages
+   (landing ↔ lab). template.tsx remounts on every navigation, so the
+   CSS enter animation re-runs on each route change.
+
+   Robustness note: the animation is purely additive. The element's
+   resting opacity is 1 (visible), and `.page-enter` only overrides it
+   for the brief fade-up. If the animation never plays (JS disabled,
+   throttled rAF, an old engine), the content is still fully visible —
+   unlike a JS wrapper that parks the page at opacity 0 until an effect
+   runs. Reduced-motion is handled centrally by the
+   prefers-reduced-motion block in globals.css, which collapses this
+   animation to an instant, motionless reveal.
+   ================================================================ */
+
+export default function Template({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div className="page-enter">{children}</div>;
+}

--- a/frontend/components/machine/FlipSwitch.tsx
+++ b/frontend/components/machine/FlipSwitch.tsx
@@ -64,10 +64,24 @@ const FlipSwitch: React.FC<FlipSwitchProps> = ({ isOn, onToggle }) => {
     setTimeout(() => setShowSparks(false), 500);
   };
 
+  // Keyboard support: Enter / Space toggle the switch, matching pointer
+  // behaviour. preventDefault stops Space from scrolling the page.
+  const handleKeyDown = (event: React.KeyboardEvent<SVGGElement>) => {
+    if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+      event.preventDefault();
+      handleClick();
+    }
+  };
+
   return (
     <g
       id="power-switch"
+      role="switch"
+      aria-checked={isOn}
+      aria-label="Start analysis engine"
+      tabIndex={0}
       onClick={handleClick}
+      onKeyDown={handleKeyDown}
       style={{ cursor: "pointer" }}
     >
       <defs>
@@ -191,6 +205,7 @@ const FlipSwitch: React.FC<FlipSwitchProps> = ({ isOn, onToggle }) => {
         r={3}
         fill="white"
         opacity={0.08}
+        initial={false}
         animate={{
           cx: isOn ? handleOnX - 2 : handleOffX - 2,
         }}

--- a/frontend/components/machine/MachineCanvas.tsx
+++ b/frontend/components/machine/MachineCanvas.tsx
@@ -43,6 +43,9 @@ const COMPONENT_RECTS: Record<
   "performance-monitor": { x: 250, y: 640, w: 300, h: 100 },
 };
 
+/* Pipeline order used for the mobile stage list (below md). */
+const STAGE_IDS = Object.keys(COMPONENT_RECTS);
+
 const MachineCanvas: React.FC<MachineCanvasProps> = ({
   isOn,
   activeComponents,
@@ -67,21 +70,92 @@ const MachineCanvas: React.FC<MachineCanvasProps> = ({
   }, []);
 
   return (
-    <div
-      ref={containerRef}
-      style={{
-        width: "100%",
-        maxWidth: 800,
-        margin: "0 auto",
-        position: "relative",
-      }}
-    >
+    <>
+      {/* ── Mobile fallback (below md) ─────────────────────
+          The 800×780 SVG machine overflows and its labels become
+          illegible on small screens, so below md we hide it and show
+          an accessible power toggle plus a vertical stage list. */}
+      <div className="mx-auto w-full max-w-md md:hidden">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={isOn}
+          aria-label={isOn ? "Stop analysis engine" : "Start analysis engine"}
+          onClick={onToggle}
+          className="mb-6 flex w-full items-center justify-between rounded-xl border border-wire-inactive bg-bg-secondary px-4 py-3 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-accent-primary"
+        >
+          <span className="heading-font text-xs uppercase tracking-widest text-text-secondary">
+            Power
+          </span>
+          <span
+            className={`text-sm font-semibold ${
+              isOn ? "text-accent-primary" : "text-text-muted"
+            }`}
+          >
+            {isOn ? "● ON" : "○ OFF"}
+          </span>
+        </button>
+
+        <ol className="space-y-2">
+          {STAGE_IDS.map((id, i) => {
+            const tip = tooltips[id];
+            if (!tip) return null;
+            const active = activeComponents.has(id);
+            return (
+              <li
+                key={id}
+                className={`rounded-lg border p-3 transition-colors ${
+                  active
+                    ? "border-accent-primary/40 bg-accent-primary/5"
+                    : "border-wire-inactive bg-bg-secondary"
+                }`}
+              >
+                <div className="flex items-center gap-2.5">
+                  <span
+                    className={`flex h-5 w-5 flex-none items-center justify-center rounded-full text-[10px] font-bold ${
+                      active
+                        ? "bg-accent-primary/20 text-accent-primary"
+                        : "bg-bg-tertiary text-text-muted"
+                    }`}
+                  >
+                    {i + 1}
+                  </span>
+                  <span
+                    className={`text-sm font-semibold ${
+                      active ? "text-accent-primary" : "text-text-primary"
+                    }`}
+                  >
+                    {tip.title}
+                  </span>
+                </div>
+                <p className="mt-1 pl-[30px] text-xs leading-relaxed text-text-secondary">
+                  {tip.subtitle}
+                </p>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      {/* ── Desktop machine (md and up) ───────────────────── */}
+      <div
+        ref={containerRef}
+        className="hidden md:block"
+        style={{
+          width: "100%",
+          maxWidth: 800,
+          margin: "0 auto",
+          position: "relative",
+        }}
+      >
       {/* ── SVG Machine ──────────────────────────────────── */}
       <svg
         viewBox="0 0 800 780"
         width="100%"
         height="100%"
         xmlns="http://www.w3.org/2000/svg"
+        role="img"
+        aria-label="Analysis engine diagram: a data pipeline feeds a concentration analyzer, which drives a mirror-index builder and an alpha optimizer, both feeding a performance monitor."
         style={{ overflow: "visible", display: "block" }}
       >
         <defs>
@@ -134,6 +208,10 @@ const MachineCanvas: React.FC<MachineCanvasProps> = ({
         return (
           <Tooltip key={id} content={tip} side="right" delayDuration={200}>
             <div
+              role="button"
+              tabIndex={0}
+              aria-label={tip.title}
+              className="rounded-md outline-none focus-visible:ring-2 focus-visible:ring-accent-primary"
               style={{
                 position: "absolute",
                 left: rect.x * scale,
@@ -142,12 +220,12 @@ const MachineCanvas: React.FC<MachineCanvasProps> = ({
                 height: rect.h * scale,
                 cursor: "pointer",
               }}
-              aria-label={tip.title}
             />
           </Tooltip>
         );
       })}
-    </div>
+      </div>
+    </>
   );
 };
 

--- a/frontend/components/results/ResultsPanel.tsx
+++ b/frontend/components/results/ResultsPanel.tsx
@@ -8,6 +8,7 @@
    ================================================================ */
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import { motion, AnimatePresence } from "framer-motion";
 import useLabData from "@/hooks/useLabData";
 import {
@@ -17,13 +18,33 @@ import {
 import type { LabData, PerformanceMetrics } from "@/lib/types";
 import GlowText from "@/components/ui/GlowText";
 import MetricCard from "./MetricCard";
-import ConcentrationChart from "./ConcentrationChart";
-import PerformanceChart from "./PerformanceChart";
-import DrawdownChart from "./DrawdownChart";
 import HoldingsTable from "./HoldingsTable";
 import ThinkingPanel from "./ThinkingPanel";
 import StrategyPlaybook from "./StrategyPlaybook";
 import HoldoutEvidence from "./HoldoutEvidence";
+
+/* ──────────────────────────────────────────────────────────────
+   Charts are code-split (next/dynamic) so the heavy Recharts bundle
+   only loads once results are revealed, keeping the initial payload
+   small. A shimmer placeholder holds the layout while each loads.
+   ────────────────────────────────────────────────────────────── */
+
+const ChartSkeleton: React.FC = () => (
+  <div className="shimmer h-80 w-full rounded-lg" />
+);
+
+const ConcentrationChart = dynamic(() => import("./ConcentrationChart"), {
+  ssr: false,
+  loading: () => <ChartSkeleton />,
+});
+const PerformanceChart = dynamic(() => import("./PerformanceChart"), {
+  ssr: false,
+  loading: () => <ChartSkeleton />,
+});
+const DrawdownChart = dynamic(() => import("./DrawdownChart"), {
+  ssr: false,
+  loading: () => <ChartSkeleton />,
+});
 
 /* ──────────────────────────────────────────────────────────────
    Props


### PR DESCRIPTION
Closes the Phase 12 polish gaps an adversarial audit confirmed. Frontend-only; branched from `origin/main`. Does **not** touch the strategy-evidence work in #84.

## What changed

### Accessibility — HIGH
1. **Keyboard-operable power switch** (`FlipSwitch.tsx`) — the entry-point interaction. The SVG `<g>` now has `role="switch"`, `aria-checked` bound to state, `aria-label`, `tabIndex={0}`, and an `onKeyDown` firing the same toggle on Enter/Space (`preventDefault` stops Space-scroll). A `:focus-visible` ring (`#power-switch` in `globals.css`) shows keyboard focus.
2. **`prefers-reduced-motion`** (`globals.css`) — a `@media (prefers-reduced-motion: reduce)` block neutralises the CSS keyframe animations (wire electricity, glow/breathe/button pulses, shimmer, float, gear) and collapses transition durations.

### Accessibility — MEDIUM
3. **Machine SVG a11y + responsive** (`MachineCanvas.tsx`) — `role="img"` + descriptive `aria-label` on the SVG; below `md` the 800×780 machine (which overflowed) is hidden and replaced by an accessible power **toggle button** + a vertical, active-aware **stage list**. No horizontal overflow at 375px.
4. **Focus-reachable tooltips** (`MachineCanvas` hotspots) — hotspots are now `role="button"` + `tabIndex={0}` with a focus ring, so Radix opens "The Thinking" on keyboard focus (confirmed: trigger gets `aria-describedby` on focus).
5. **Open Graph image** (`app/opengraph-image.tsx` via `next/og`) — a generated 1200×630 card. The Next.js file convention auto-injects `og:image`/`twitter:image` (verified in the built `<head>` with width/height/alt), so a manual `openGraph.images` entry is intentionally omitted (it would duplicate the tag). `layout.tsx` sets `metadataBase` (VERCEL_URL in prod, localhost in dev) so URLs resolve absolutely without hardcoding a domain.

### Polish — LOW
6. **Code-split charts** (`ResultsPanel.tsx`) — the three Recharts charts load via `next/dynamic` with a shimmer fallback, so the heavy chart bundle loads only when results appear.
7. **Page transition** (`app/template.tsx`) — a per-route enter transition (landing↔lab). Implemented in **CSS** (`.page-enter`, reusing `fadeInUp`) rather than a framer-motion wrapper: the resting opacity stays **1**, so the page is never parked invisible if the animation doesn't run. Auto-gated by the reduced-motion block. (A JS wrapper was prototyped first but parked the full page at `opacity:0` until an effect ran — rejected as too fragile.)

**Bonus:** silenced a pre-existing framer-motion `animate cx from "undefined"` warning on the FlipSwitch highlight circle (`initial={false}`, matching its sibling) for a clean console.

## Verification
- `npm run lint` ✅ and `npm run build` ✅ (clean — no font/metadata warnings; `/opengraph-image` prerenders static).
- Browser preview: Enter/Space toggle + focus ring ✅; focus opens tooltips (`aria-describedby` wired) ✅; mobile (375px) shows toggle + stage list, SVG hidden, no h-overflow ✅; mobile toggle drives the engine ✅; all 3 code-split charts render (shimmer→chart) ✅; OG image renders with all glyphs ✅; **no console errors or hydration warnings** ✅.
- Reduced-motion: verified the media rule ships correctly (global `animation-duration: 0.01ms !important` + `animation: none` on the named utilities). Runtime toggling of the OS setting isn't exposable via the preview tools (no CDP media emulation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)