### PR TITLE
fix(lab): matched-window comparison + significance disclosure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 S&P Index Lab proves the S&P 500 is effectively a ~20-stock index. Python backend computes analytics (OLS regression, variance decomposition, mirror index construction). React frontend displays results via an interactive machine-metaphor visualization. Static JSON bridge between the two — no Python at runtime.
 
-Key results (point-in-time universe, net of transaction costs, vs S&P 500 total-return;
-full out-of-sample 2016→present unless noted). No single strategy is crowned — the site
-shows all four side by side:
-- R² ≈ 95.2% with 20 stocks (mean across rolling 1-year windows, PIT top-20 per window)
-- S&P 500 TR: CAGR ~13.9%
-- SP-20 Mirror: CAGR ~17.2%, Jensen alpha ~+2.3%
-- SP-20 Equal: CAGR ~15.7%, Jensen alpha ~+2.0%
-- SP-N Alpha (self-adjusting concentration-elbow, dynamic N 10–30, equal-weighted):
-  CAGR ~20.3%, Sharpe ~0.88, Jensen alpha ~+3.8%, turnover ~1.8x
+Key results (point-in-time universe, net of transaction costs, vs S&P 500 total-return).
+No single strategy is crowned — the site shows all four side by side:
+- R² ≈ 95.2% with 20 stocks (mean across rolling 1-year windows, PIT top-20 per window).
+  This is the project's one statistically strong claim.
+- **Always quote the matched window** (2016-01-04→present, ~10.5y — the first date all four
+  series exist), from the `matched_window` block in `performance_metrics.json`:
+  S&P 500 ~15.4% CAGR · SP-20 Mirror ~19.3% · SP-20 Equal ~17.5% · SP-N Alpha ~20.3%.
+  The per-strategy blocks each span that strategy's OWN history (baselines from 2014,
+  SP-N Alpha from 2016 once its first walk-forward window closes). Comparing across those
+  is not apples-to-apples: it understates the S&P by ~1.5pp CAGR and lets a longer window
+  win on total return purely by compounding longer.
+- **No pairwise difference is statistically significant.** On the matched window, SP-N Alpha
+  beats the Mirror by only ~+0.9pp/yr (TE ~3.9%, IR ~0.22, t ≈ 0.7) — it would need ~178
+  years of data to clear the t > 3.0 multiple-testing hurdle. Even Alpha vs the S&P 500 is
+  t ≈ 2.0 (~25 years needed). Never describe any strategy as "beating" another without
+  this caveat; the ranking is real in the data and indistinguishable from luck.
+- Root cause is breadth, not costs: cost drag is only ~6–15 bps/yr (Mirror 0.83x turnover,
+  Equal 1.15x, Alpha ~1.8–2.0x) and mega-cap capacity is effectively unbounded. Grinold's
+  IR ≈ IC×√breadth caps what 20 names × 12 rebalances can demonstrate.
 
 Honest-evaluation protocol (the point of the project — do not regress these):
 - **Dev/holdout split**: `DEV_END=2023-12-31`. All development, tuning, and variant
@@ -31,8 +41,17 @@ Honest-evaluation protocol (the point of the project — do not regress these):
   the **dividend-unadjusted** `daily_prices_raw` panel (`src/data/universe.py`). Returns
   use the dividend-adjusted panel. Never rank by full-sample statistics.
 - All backtests net of turnover costs (`src/backtest/costs.py`). Benchmark is ^SP500TR.
+- **Significance hurdle**: `MULTIPLE_TESTING_T_HURDLE = 3.0` (`src/config.py`), per Harvey,
+  Liu & Zhu (2016) — with 14 logged dev trials the conventional t > 1.96 is invalid. The
+  `matched_window.significance` block reports the t-stat of every pairwise comparison and
+  `years_for_hurdle` (t = IR × √years), surfaced by `SignificancePanel.tsx`.
+- **SP-20 Mirror has never been a research reference.** All 14 dev trials scored only
+  against `^SP500TR` and `sp20_equal`, so no candidate has a dev-window excess-vs-Mirror
+  record. Any new race targeting the Mirror must add it to `references` and pre-register
+  updated criteria BEFORE selecting a candidate.
 - Exact current numbers live in `frontend/public/data/meta.json` (`headline` + `research`
-  blocks); components read them — never hardcode numbers in components or docs.
+  blocks) and `performance_metrics.json` (`matched_window`); components read them — never
+  hardcode numbers in components or docs.
 
 ## Commands
 

--- a/frontend/components/results/ResultsPanel.tsx
+++ b/frontend/components/results/ResultsPanel.tsx
@@ -22,6 +22,7 @@ import HoldingsTable from "./HoldingsTable";
 import ThinkingPanel from "./ThinkingPanel";
 import StrategyPlaybook from "./StrategyPlaybook";
 import HoldoutEvidence from "./HoldoutEvidence";
+import { SignificancePanel } from "./SignificancePanel";
 
 /* ──────────────────────────────────────────────────────────────
    Charts are code-split (next/dynamic) so the heavy Recharts bundle
@@ -74,21 +75,43 @@ interface MetricRowDef {
   format: (v: number) => string;
   /** Higher is better (true) or lower is better (false, e.g., drawdown) */
   higherIsBetter: boolean;
+  /**
+   * Metric defined *relative to* the benchmark, where the benchmark's own
+   * value is definitional rather than earned (its tracking error is 0.00% and
+   * its information ratio 0.00 by construction). Marking those as the "best"
+   * value is meaningless, so the benchmark column is excluded from ranking.
+   */
+  relativeToBenchmark?: boolean;
+  /**
+   * Metric that scales with window length rather than skill. Total return
+   * compounds, so a longer-running series can top the column purely by having
+   * existed longer — never rank it while the columns span different windows.
+   */
+  windowSensitive?: boolean;
 }
 
 const METRIC_ROWS: MetricRowDef[] = [
-  { label: "Total Return", key: "totalReturn", format: (v) => formatPercent(v, 1), higherIsBetter: true },
+  { label: "Total Return", key: "totalReturn", format: (v) => formatPercent(v, 1), higherIsBetter: true, windowSensitive: true },
   { label: "CAGR", key: "cagr", format: (v) => formatPercent(v, 1), higherIsBetter: true },
   { label: "Annualised Volatility", key: "annualizedVolatility", format: (v) => formatPercent(v, 1), higherIsBetter: false },
   { label: "Sharpe Ratio", key: "sharpe", format: (v) => formatRatio(v), higherIsBetter: true },
   { label: "Sortino Ratio", key: "sortino", format: (v) => formatRatio(v), higherIsBetter: true },
   { label: "Max Drawdown", key: "maxDrawdown", format: (v) => formatPercent(v, 1), higherIsBetter: false },
   { label: "Calmar Ratio", key: "calmar", format: (v) => formatRatio(v), higherIsBetter: true },
-  { label: "Beta", key: "beta", format: (v) => formatRatio(v), higherIsBetter: false },
-  { label: "Alpha", key: "alpha", format: (v) => formatPercent(v, 1), higherIsBetter: true },
-  { label: "Tracking Error", key: "trackingError", format: (v) => formatPercent(v, 2), higherIsBetter: false },
-  { label: "Information Ratio", key: "informationRatio", format: (v) => formatRatio(v), higherIsBetter: true },
+  { label: "Beta", key: "beta", format: (v) => formatRatio(v), higherIsBetter: false, relativeToBenchmark: true },
+  { label: "Alpha", key: "alpha", format: (v) => formatPercent(v, 1), higherIsBetter: true, relativeToBenchmark: true },
+  { label: "Tracking Error", key: "trackingError", format: (v) => formatPercent(v, 2), higherIsBetter: false, relativeToBenchmark: true },
+  { label: "Information Ratio", key: "informationRatio", format: (v) => formatRatio(v), higherIsBetter: true, relativeToBenchmark: true },
 ];
+
+/** Column order of the comparison table, paired with raw export keys so the
+ *  significance lookup (which is keyed by export key) can find each column. */
+const COMPARISON_COLUMNS = [
+  { label: "S&P 500", exportKey: "sp500" },
+  { label: "SP-20 Mirror", exportKey: "sp20_mirror" },
+  { label: "SP-20 Equal", exportKey: "sp20_equal" },
+  { label: "SP-N Alpha", exportKey: "spn_alpha" },
+] as const;
 
 /* ──────────────────────────────────────────────────────────────
    Helper: determine the best value index in a row
@@ -97,31 +120,29 @@ const METRIC_ROWS: MetricRowDef[] = [
 function getBestIndex(
   values: number[],
   higherIsBetter: boolean,
+  excludeIndices: readonly number[] = [],
 ): number {
-  if (values.length === 0) return -1;
+  const candidates = values
+    .map((value, index) => ({ value, index }))
+    .filter(({ index }) => !excludeIndices.includes(index));
 
-  if (!higherIsBetter) {
-    const allValuesAreNonPositive = values.every((v) => v <= 0);
-    let bestIdx = 0;
-    for (let i = 1; i < values.length; i++) {
-      const isBetter = allValuesAreNonPositive
-        ? values[i] > values[bestIdx]
-        : values[i] < values[bestIdx];
-      if (isBetter) {
-        bestIdx = i;
-      }
-    }
-    return bestIdx;
-  }
+  if (candidates.length === 0) return -1;
 
-  // For higher is better
-  let bestIdx = 0;
-  for (let i = 1; i < values.length; i++) {
-    if (values[i] > values[bestIdx]) {
-      bestIdx = i;
-    }
+  // Drawdowns are all non-positive, where "best" means closest to zero, i.e.
+  // the largest value — the opposite of the usual lower-is-better ordering.
+  const allValuesAreNonPositive =
+    !higherIsBetter && candidates.every(({ value }) => value <= 0);
+
+  let best = candidates[0];
+  for (const candidate of candidates.slice(1)) {
+    const isBetter = higherIsBetter
+      ? candidate.value > best.value
+      : allValuesAreNonPositive
+        ? candidate.value > best.value
+        : candidate.value < best.value;
+    if (isBetter) best = candidate;
   }
-  return bestIdx;
+  return best.index;
 }
 
 /* ──────────────────────────────────────────────────────────────
@@ -451,91 +472,138 @@ const ResultsPanel: React.FC<ResultsPanelProps> = ({ visible }) => {
                 transition={{ duration: 0.5, ease: "easeOut" }}
                 className="mt-6 overflow-x-auto rounded-xl border border-[#1A1A24] bg-bg-secondary p-6"
               >
-                <h3 className="mb-4 text-sm font-semibold tracking-wide text-text-secondary">
-                  Performance Comparison
-                </h3>
+                {(() => {
+                  const matched = data.performanceMetrics.matchedWindow;
+                  // Prefer the matched-window block: every series re-based to
+                  // the first date they all share. Without it we fall back to
+                  // each strategy's own window, which is NOT comparable — the
+                  // rendering below suppresses window-sensitive ranking then.
+                  const source = matched?.metrics ?? data.performanceMetrics;
+                  const columns = COMPARISON_COLUMNS.filter(
+                    (col) => col.exportKey !== "spn_alpha" || source.spnAlpha,
+                  );
+                  const metricsByColumn: PerformanceMetrics[] = columns.map(
+                    (col) =>
+                      col.exportKey === "sp500"
+                        ? source.sp500
+                        : col.exportKey === "sp20_mirror"
+                          ? source.sp20Mirror
+                          : col.exportKey === "sp20_equal"
+                            ? source.sp20Equal
+                            : source.spnAlpha!,
+                  );
+                  const benchmarkIdx = columns.findIndex(
+                    (col) => col.exportKey === (matched?.benchmark ?? "sp500"),
+                  );
 
-                <table className="w-full text-left text-sm">
-                  <thead>
-                    <tr className="border-b border-[#1A1A24]">
-                      <th className="px-3 py-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
-                        Metric
-                      </th>
-                      <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
-                        S&P 500
-                      </th>
-                      <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
-                        SP-20 Mirror
-                      </th>
-                      <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
-                        SP-20 Equal
-                      </th>
-                      {data.performanceMetrics.spnAlpha && (
-                        <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
-                          SP-N Alpha*
-                        </th>
-                      )}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {METRIC_ROWS.map((row, idx) => {
-                      const sp500Val = data.performanceMetrics.sp500[row.key];
-                      const mirrorVal = data.performanceMetrics.sp20Mirror[row.key];
-                      const equalVal = data.performanceMetrics.sp20Equal[row.key];
-                      const alphaVal = data.performanceMetrics.spnAlpha?.[row.key];
-
-                      const values: number[] = [sp500Val, mirrorVal, equalVal];
-                      if (alphaVal !== undefined) values.push(alphaVal);
-
-                      const bestIdx = getBestIndex(values, row.higherIsBetter);
-
-                      return (
-                        <tr
-                          key={row.key}
-                          className={`border-b border-[#1A1A24] ${
-                            idx % 2 === 0 ? "bg-bg-secondary" : "bg-bg-primary"
-                          }`}
-                        >
-                          <td className="px-3 py-2.5 text-xs text-text-secondary">
-                            {row.label}
-                          </td>
-                          {values.map((val, colIdx) => (
-                            <td
-                              key={colIdx}
-                              className={`px-3 py-2.5 text-right font-mono text-xs tabular-nums ${
-                                colIdx === bestIdx
-                                  ? "font-bold text-accent-primary"
-                                  : "text-text-primary"
-                              }`}
-                            >
-                              {row.format(val)}
-                            </td>
-                          ))}
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-
-                <p className="mt-3 text-[11px] leading-relaxed text-text-muted">
-                  All strategy returns are net of transaction costs (7 bps per
-                  one-way traded notional) on a point-in-time top-20 universe,
-                  benchmarked against the S&amp;P 500 total-return index.
-                  {data.performanceMetrics.spnAlpha?.windowStart && (
+                  return (
                     <>
-                      {" "}
-                      *SP-N Alpha is out-of-sample walk-forward from{" "}
-                      {data.performanceMetrics.spnAlpha.windowStart} (
-                      {data.performanceMetrics.spnAlpha.windowYears?.toFixed(1)}{" "}
-                      years); baseline columns start at{" "}
-                      {data.performanceMetrics.sp500.windowStart ??
-                        data.meta.startDate}
-                      , so CAGRs span different windows — relative metrics
-                      (alpha, tracking error) are computed on overlapping dates.
+                      <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+                        <h3 className="text-sm font-semibold tracking-wide text-text-secondary">
+                          Performance Comparison
+                        </h3>
+                        <span className="font-mono text-[11px] text-text-muted">
+                          {matched
+                            ? `matched window ${matched.windowStart} → ${matched.windowEnd} (${matched.windowYears.toFixed(1)}y)`
+                            : "each column spans its own window — not directly comparable"}
+                        </span>
+                      </div>
+
+                      <table className="w-full text-left text-sm">
+                        <thead>
+                          <tr className="border-b border-[#1A1A24]">
+                            <th className="px-3 py-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
+                              Metric
+                            </th>
+                            {columns.map((col) => (
+                              <th
+                                key={col.exportKey}
+                                className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted"
+                              >
+                                {col.label}
+                              </th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {METRIC_ROWS.map((row, idx) => {
+                            const values = metricsByColumn.map((m) => m[row.key]);
+
+                            // Two cases where crowning a "winner" would mislead:
+                            // a relative metric (the benchmark's own tracking
+                            // error is 0.00% by construction), and a
+                            // window-sensitive metric on unmatched columns.
+                            const excluded = row.relativeToBenchmark
+                              ? [benchmarkIdx]
+                              : [];
+                            const rankable = !(row.windowSensitive && !matched);
+                            const bestIdx = rankable
+                              ? getBestIndex(values, row.higherIsBetter, excluded)
+                              : -1;
+
+                            return (
+                              <tr
+                                key={row.key}
+                                className={`border-b border-[#1A1A24] ${
+                                  idx % 2 === 0 ? "bg-bg-secondary" : "bg-bg-primary"
+                                }`}
+                              >
+                                <td className="px-3 py-2.5 text-xs text-text-secondary">
+                                  {row.label}
+                                </td>
+                                {values.map((val, colIdx) => (
+                                  <td
+                                    key={columns[colIdx].exportKey}
+                                    className={`px-3 py-2.5 text-right font-mono text-xs tabular-nums ${
+                                      colIdx === bestIdx
+                                        ? "font-semibold text-text-primary underline decoration-text-muted decoration-dotted underline-offset-4"
+                                        : "text-text-primary"
+                                    }`}
+                                  >
+                                    {row.format(val)}
+                                  </td>
+                                ))}
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+
+                      <p className="mt-3 text-[11px] leading-relaxed text-text-muted">
+                        All strategy returns are net of transaction costs (7 bps
+                        per one-way traded notional) on a point-in-time top-20
+                        universe, benchmarked against the S&amp;P 500
+                        total-return index.{" "}
+                        {matched ? (
+                          <>
+                            Every column is re-based to{" "}
+                            {matched.windowStart}, the first date all four
+                            series exist, so the comparison is like-for-like.
+                            Underlining marks the leading value; it is not a
+                            claim that the lead is real — see below.
+                          </>
+                        ) : (
+                          <>
+                            SP-N Alpha is out-of-sample walk-forward from{" "}
+                            {source.spnAlpha?.windowStart} (
+                            {source.spnAlpha?.windowYears?.toFixed(1)} years)
+                            while the baselines start at{" "}
+                            {source.sp500.windowStart ?? data.meta.startDate},
+                            so these columns span different windows. Total
+                            return is left unranked because a longer window
+                            compounds more regardless of skill.
+                          </>
+                        )}
+                      </p>
                     </>
-                  )}
-                </p>
+                  );
+                })()}
               </motion.div>
+
+              {/* ── Is any of it real? ────────────────────────── */}
+              {data.performanceMetrics.matchedWindow && (
+                <SignificancePanel matched={data.performanceMetrics.matchedWindow} />
+              )}
 
               {/* ── How Each Portfolio Works ──────────────────── */}
               <SectionHeader>How Each Portfolio Works</SectionHeader>

--- a/frontend/components/results/SignificancePanel.tsx
+++ b/frontend/components/results/SignificancePanel.tsx
@@ -151,7 +151,11 @@ export function SignificancePanel({ matched }: SignificancePanelProps) {
 
       <p className="mt-3 max-w-3xl text-[11px] leading-relaxed text-text-muted">
         Measured on daily active returns over the matched window (
-        {matched.windowStart} → {matched.windowEnd}). &ldquo;Years to Prove&rdquo;
+        {matched.windowStart} → {matched.windowEnd}). The information ratio here
+        is arithmetic (mean daily active return over its own volatility) so that
+        t = IR × √years holds exactly; the table above reports the canonical
+        CAGR-excess-over-tracking-error version, so the two differ slightly.
+        &ldquo;Years to Prove&rdquo;
         is how long this information ratio would need to run to reach |t| &gt;{" "}
         {matched.tHurdle.toFixed(1)}, since t = IR × √years; it is shown as
         &ldquo;&mdash;&rdquo; where the strategy trails its reference, because no

--- a/frontend/components/results/SignificancePanel.tsx
+++ b/frontend/components/results/SignificancePanel.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * SignificancePanel — the honest reading of the comparison table.
+ *
+ * A performance table invites the eye to rank columns. With ~10 years of one
+ * highly-correlated mega-cap universe, those gaps are mostly noise: the
+ * strategies share the same ~20 names, so their active returns are small
+ * relative to their tracking error. This panel states that outright rather
+ * than leaving a bold number to imply an edge that the data cannot support.
+ *
+ * The hurdle is |t| > 3.0, not the conventional 1.96 — Harvey, Liu & Zhu
+ * (2016) show that after extensive search across strategy variants the usual
+ * threshold is meaningless. This project has logged 14 dev trials, so the
+ * stricter bar is the correct one.
+ */
+
+import { motion } from "framer-motion";
+
+import type { ActiveReturnStats, MatchedWindowComparison } from "@/lib/types";
+
+/** Comparisons worth showing. Reversed pairs are omitted: "S&P 500 vs Mirror"
+ *  is just the negation of "Mirror vs S&P 500" and adds no information. */
+const COMPARISONS: { strategy: string; reference: string; label: string }[] = [
+  { strategy: "sp20_mirror", reference: "sp500", label: "SP-20 Mirror vs S&P 500" },
+  { strategy: "sp20_equal", reference: "sp500", label: "SP-20 Equal vs S&P 500" },
+  { strategy: "spn_alpha", reference: "sp500", label: "SP-N Alpha vs S&P 500" },
+  { strategy: "sp20_mirror", reference: "sp20_equal", label: "SP-20 Mirror vs SP-20 Equal" },
+  { strategy: "spn_alpha", reference: "sp20_equal", label: "SP-N Alpha vs SP-20 Equal" },
+  { strategy: "spn_alpha", reference: "sp20_mirror", label: "SP-N Alpha vs SP-20 Mirror" },
+];
+
+function formatYears(years: number | null): string {
+  if (years === null) return "—";
+  return years >= 1000 ? "1000+" : `~${Math.round(years)}`;
+}
+
+interface SignificancePanelProps {
+  matched: MatchedWindowComparison;
+}
+
+export function SignificancePanel({ matched }: SignificancePanelProps) {
+  const rows = COMPARISONS.map((comparison) => ({
+    ...comparison,
+    stats: matched.significance[comparison.strategy]?.[comparison.reference],
+  })).filter(
+    (row): row is typeof row & { stats: ActiveReturnStats } => !!row.stats,
+  );
+
+  if (rows.length === 0) return null;
+
+  const significantCount = rows.filter((row) => row.stats.significant).length;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "-50px" }}
+      transition={{ duration: 0.5, ease: "easeOut" }}
+      className="mt-6 overflow-x-auto rounded-xl border border-[#1A1A24] bg-bg-secondary p-6"
+    >
+      <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-sm font-semibold tracking-wide text-text-secondary">
+          Is any of that difference real?
+        </h3>
+        <span className="font-mono text-[11px] text-text-muted">
+          hurdle |t| &gt; {matched.tHurdle.toFixed(1)} · {matched.windowYears.toFixed(1)}y of data
+        </span>
+      </div>
+
+      <p className="mb-4 max-w-3xl text-xs leading-relaxed text-text-secondary">
+        {significantCount === 0 ? (
+          <>
+            No. <span className="text-text-primary">Not one</span> of these
+            comparisons clears the significance hurdle — every ranking in the
+            table above is statistically indistinguishable from luck. The
+            strategies hold overlapping slices of the same ~20 mega-caps, so
+            their active returns are small next to their tracking error, and{" "}
+            {matched.windowYears.toFixed(1)} years is nowhere near enough data
+            to tell them apart.
+          </>
+        ) : (
+          <>
+            {significantCount} of {rows.length} comparisons clear the hurdle.
+            The rest are statistically indistinguishable from luck.
+          </>
+        )}
+      </p>
+
+      <table className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-[#1A1A24]">
+            <th className="px-3 py-3 text-xs font-semibold uppercase tracking-wider text-text-muted">
+              Comparison
+            </th>
+            <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
+              Active Return
+            </th>
+            <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
+              Tracking Error
+            </th>
+            <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
+              Info Ratio
+            </th>
+            <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
+              t-stat
+            </th>
+            <th className="px-3 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
+              Years to Prove
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => (
+            <tr
+              key={`${row.strategy}-${row.reference}`}
+              className={`border-b border-[#1A1A24] ${
+                idx % 2 === 0 ? "bg-bg-secondary" : "bg-bg-primary"
+              }`}
+            >
+              <td className="px-3 py-2.5 text-xs text-text-secondary">
+                {row.label}
+              </td>
+              <td className="px-3 py-2.5 text-right font-mono text-xs tabular-nums text-text-primary">
+                {row.stats.annualisedActiveReturn >= 0 ? "+" : ""}
+                {(row.stats.annualisedActiveReturn * 100).toFixed(2)}%
+              </td>
+              <td className="px-3 py-2.5 text-right font-mono text-xs tabular-nums text-text-primary">
+                {(row.stats.trackingError * 100).toFixed(2)}%
+              </td>
+              <td className="px-3 py-2.5 text-right font-mono text-xs tabular-nums text-text-primary">
+                {row.stats.informationRatio.toFixed(2)}
+              </td>
+              <td
+                className={`px-3 py-2.5 text-right font-mono text-xs tabular-nums ${
+                  row.stats.significant
+                    ? "font-bold text-accent-primary"
+                    : "text-text-muted"
+                }`}
+              >
+                {row.stats.tStat >= 0 ? "+" : ""}
+                {row.stats.tStat.toFixed(2)}
+              </td>
+              <td className="px-3 py-2.5 text-right font-mono text-xs tabular-nums text-text-muted">
+                {formatYears(row.stats.yearsForHurdle)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <p className="mt-3 max-w-3xl text-[11px] leading-relaxed text-text-muted">
+        Measured on daily active returns over the matched window (
+        {matched.windowStart} → {matched.windowEnd}). &ldquo;Years to Prove&rdquo;
+        is how long this information ratio would need to run to reach |t| &gt;{" "}
+        {matched.tHurdle.toFixed(1)}, since t = IR × √years; it is shown as
+        &ldquo;&mdash;&rdquo; where the strategy trails its reference, because no
+        amount of data would make a negative edge significant. The
+        hurdle follows Harvey, Liu &amp; Zhu (2016), who show the conventional
+        t &gt; 1.96 is invalid once many variants have been searched over. This
+        project has logged 14 development trials, so the stricter bar applies.
+      </p>
+    </motion.div>
+  );
+}

--- a/frontend/hooks/useLabData.ts
+++ b/frontend/hooks/useLabData.ts
@@ -17,8 +17,11 @@ import type {
   VarianceDecompositionPoint,
   PerformanceNavData,
   PerformanceNavPoint,
+  ActiveReturnStats,
   AllPerformanceMetrics,
+  MatchedWindowComparison,
   PerformanceMetrics,
+  StrategyMetricSet,
   HoldingsData,
   Holding,
   DrawdownData,
@@ -284,15 +287,67 @@ function transformSingleMetrics(m: any): PerformanceMetrics {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function transformPerformanceMetrics(raw: any): AllPerformanceMetrics {
-  const result: AllPerformanceMetrics = {
+function transformMetricSet(raw: any): StrategyMetricSet {
+  const set: StrategyMetricSet = {
     sp500: transformSingleMetrics(raw.sp500 || {}),
     sp20Mirror: transformSingleMetrics(raw.sp20_mirror || raw.sp20Mirror || {}),
     sp20Equal: transformSingleMetrics(raw.sp20_equal || raw.sp20Equal || {}),
   };
   const alphaRaw = raw.spn_alpha ?? raw.spnAlpha;
-  if (alphaRaw) result.spnAlpha = transformSingleMetrics(alphaRaw);
-  return result;
+  if (alphaRaw) set.spnAlpha = transformSingleMetrics(alphaRaw);
+  return set;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformActiveReturnStats(raw: any): ActiveReturnStats {
+  return {
+    annualisedActiveReturn: raw.annualised_active_return ?? 0,
+    trackingError: raw.tracking_error ?? 0,
+    informationRatio: raw.information_ratio ?? 0,
+    tStat: raw.t_stat ?? 0,
+    significant: !!raw.significant,
+    yearsForHurdle: raw.years_for_hurdle ?? null,
+    nDays: raw.n_days ?? 0,
+  };
+}
+
+/**
+ * The matched-window block is optional: it only exists after the export has
+ * been regenerated. Older bundles simply omit it and the UI falls back to the
+ * per-strategy (unmatched) metrics, so this must never throw on absence.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformMatchedWindow(raw: any): MatchedWindowComparison | undefined {
+  if (!raw?.metrics) return undefined;
+
+  const significance: Record<string, Record<string, ActiveReturnStats>> = {};
+  for (const [key, against] of Object.entries(raw.significance ?? {})) {
+    significance[key] = Object.fromEntries(
+      Object.entries(against as Record<string, unknown>).map(([ref, stats]) => [
+        ref,
+        transformActiveReturnStats(stats),
+      ]),
+    );
+  }
+
+  return {
+    windowStart: raw.window?.start ?? "",
+    windowEnd: raw.window?.end ?? "",
+    windowYears: raw.window?.n_years ?? 0,
+    benchmark: raw.benchmark ?? "sp500",
+    tHurdle: raw.t_hurdle ?? 3.0,
+    anySignificant: !!raw.any_significant,
+    metrics: transformMetricSet(raw.metrics),
+    significance,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function transformPerformanceMetrics(raw: any): AllPerformanceMetrics {
+  return {
+    ...transformMetricSet(raw),
+    matchedWindow: transformMatchedWindow(raw.matched_window ?? raw.matchedWindow),
+  };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -257,11 +257,58 @@ export interface PerformanceMetrics {
   annualizedTurnover?: number;
 }
 
-export interface AllPerformanceMetrics {
+export interface StrategyMetricSet {
   sp500: PerformanceMetrics;
   sp20Mirror: PerformanceMetrics;
   sp20Equal: PerformanceMetrics;
   spnAlpha?: PerformanceMetrics;
+}
+
+/** Significance of one strategy's active return against a reference series. */
+export interface ActiveReturnStats {
+  /** Annualised mean active return vs the reference */
+  annualisedActiveReturn: number;
+  /** Annualised standard deviation of the active return */
+  trackingError: number;
+  /** Information ratio (active return / tracking error) */
+  informationRatio: number;
+  /** t-statistic of the mean daily active return */
+  tStat: number;
+  /** Whether |t| clears the multiple-testing hurdle (Harvey-Liu-Zhu, t > 3) */
+  significant: boolean;
+  /** Years of data this IR would need to reach the hurdle; null if IR <= 0 */
+  yearsForHurdle: number | null;
+  /** Overlapping observations behind the estimate */
+  nDays: number;
+}
+
+/**
+ * Every strategy measured on the window they all share.
+ *
+ * The top-level metrics each span that strategy's own history (baselines from
+ * 2014, SP-N Alpha from 2016 once its first walk-forward window closes), so
+ * reading them as columns of one table is not apples-to-apples. This block is
+ * the honest comparison, plus the pairwise t-stats needed to say whether any
+ * gap is distinguishable from noise.
+ */
+export interface MatchedWindowComparison {
+  windowStart: string;
+  windowEnd: string;
+  windowYears: number;
+  /** Series key used as the regression benchmark (e.g. "sp500") */
+  benchmark: string;
+  /** |t| required to call a difference real */
+  tHurdle: number;
+  /** True if ANY pairwise comparison clears the hurdle */
+  anySignificant: boolean;
+  metrics: StrategyMetricSet;
+  /** significance[strategyKey][referenceKey], keyed by raw export keys */
+  significance: Record<string, Record<string, ActiveReturnStats>>;
+}
+
+export interface AllPerformanceMetrics extends StrategyMetricSet {
+  /** Present once the export has regenerated; absent on older data bundles. */
+  matchedWindow?: MatchedWindowComparison;
 }
 
 /* ──────────────────────────────────────────────────────────────

--- a/scripts/export_frontend_data.py
+++ b/scripts/export_frontend_data.py
@@ -30,6 +30,7 @@ from src.config import (
     DATA_DIR,
     DEFAULT_RISK_FREE_RATE,
     INCEPTION_DATE,
+    MULTIPLE_TESTING_T_HURDLE,
     TRADING_DAYS_PER_YEAR,
 )
 from src.data.storage import load_parquet
@@ -496,6 +497,132 @@ def _window_info(nav: pd.Series) -> dict[str, Any]:
     }
 
 
+def _active_return_stats(nav: pd.Series, reference_nav: pd.Series) -> dict[str, Any]:
+    """Significance of one NAV's active return against a reference NAV.
+
+    Reports the annualised active return, tracking error, information ratio
+    and the t-statistic of the mean daily active return. ``significant`` is
+    measured against ``MULTIPLE_TESTING_T_HURDLE`` (t > 3.0), not the naive
+    t > 1.96 — this project has run many strategy variants, and Harvey, Liu &
+    Zhu (2016) show the conventional threshold is meaningless under that kind
+    of search.
+
+    ``years_for_hurdle`` answers the question the t-stat implies but does not
+    state: at this information ratio, how many years of data would be needed
+    to reach the hurdle? Since t = IR x sqrt(years), that is (hurdle / IR)^2.
+    It is None when the information ratio is non-positive (no amount of data
+    makes a negative edge significant in the intended direction).
+    """
+    returns = nav.pct_change().dropna()
+    ref_returns = reference_nav.pct_change().dropna()
+    common = returns.index.intersection(ref_returns.index)
+
+    if len(common) < 30:
+        return {}
+
+    active = returns.loc[common] - ref_returns.loc[common]
+    n = len(active)
+    mean = float(active.mean())
+    sd = float(active.std())
+
+    if sd <= 0:
+        return {}
+
+    ann_active = mean * TRADING_DAYS_PER_YEAR
+    tracking_error = sd * math.sqrt(TRADING_DAYS_PER_YEAR)
+    info_ratio = ann_active / tracking_error
+    t_stat = mean / (sd / math.sqrt(n))
+
+    years_for_hurdle = (
+        round((MULTIPLE_TESTING_T_HURDLE / info_ratio) ** 2, 1)
+        if info_ratio > 0
+        else None
+    )
+
+    return {
+        "annualised_active_return": round(ann_active, 6),
+        "tracking_error": round(tracking_error, 6),
+        "information_ratio": round(info_ratio, 6),
+        "t_stat": round(t_stat, 4),
+        "significant": bool(abs(t_stat) > MULTIPLE_TESTING_T_HURDLE),
+        "years_for_hurdle": years_for_hurdle,
+        "n_days": int(n),
+    }
+
+
+def _matched_window_comparison(
+    navs: dict[str, pd.Series],
+    benchmark_key: str = "sp500",
+    risk_free_rate: float = _FALLBACK_RISK_FREE_RATE,
+) -> dict[str, Any]:
+    """Recompute every strategy's metrics on the window they all share.
+
+    The top-level blocks in performance_metrics.json each cover that
+    strategy's own history: the baselines run from inception (2014) while
+    SP-N Alpha only starts once its first walk-forward training window closes
+    (2016). Reading those columns side by side is not apples-to-apples —
+    total return especially, since a longer window simply compounds more, and
+    a shorter-but-faster-compounding strategy can look like it lost.
+
+    This mirrors what ``export_performance_nav`` already does for the chart:
+    intersect to common dates, re-base every series to 1.0, then measure. It
+    also carries pairwise significance so the UI can say whether a gap is
+    distinguishable from noise instead of implying it with a bold number.
+    """
+    aligned = pd.DataFrame(navs).dropna()
+    if len(aligned) < TRADING_DAYS_PER_YEAR:
+        logger.warning(
+            "Matched window too short (%d days) — skipping comparison block",
+            len(aligned),
+        )
+        return {}
+
+    # Re-base so every series starts at 1.0 on the first shared date.
+    aligned = aligned.div(aligned.iloc[0])
+    benchmark_nav = aligned[benchmark_key]
+
+    metrics: dict[str, Any] = {}
+    for key in aligned.columns:
+        nav = aligned[key]
+        relative_to = None if key == benchmark_key else benchmark_nav
+        block = compute_performance_metrics(
+            nav, relative_to, risk_free_rate=risk_free_rate
+        )
+        block.update(_compute_extra_metrics(nav, relative_to))
+        block["window"] = _window_info(nav)
+        metrics[key] = _clean_dict(block)
+
+    # Every ordered pair — the UI decides which comparisons to surface, and
+    # "Mirror vs Equal" matters as much as "Alpha vs S&P 500" when the point
+    # is that none of the gaps clear the hurdle.
+    significance: dict[str, dict[str, Any]] = {}
+    for key in aligned.columns:
+        against = {
+            ref: stats
+            for ref in aligned.columns
+            if ref != key
+            and (stats := _active_return_stats(aligned[key], aligned[ref]))
+        }
+        if against:
+            significance[key] = against
+
+    any_significant = any(
+        pair.get("significant", False)
+        for pairs in significance.values()
+        for pair in pairs.values()
+    )
+
+    return {
+        "window": _window_info(aligned[benchmark_key]),
+        "risk_free_rate": round(risk_free_rate, 6),
+        "benchmark": benchmark_key,
+        "t_hurdle": MULTIPLE_TESTING_T_HURDLE,
+        "any_significant": any_significant,
+        "metrics": metrics,
+        "significance": significance,
+    }
+
+
 def _cost_info(
     nav_gross: pd.Series | None,
     turnover: pd.Series | None,
@@ -569,6 +696,31 @@ def export_performance_metrics(
         alpha_metrics["window"] = _window_info(alpha_nav)
         alpha_metrics.update(extras.get("spn_alpha", {}))
         payload["spn_alpha"] = _clean_dict(alpha_metrics)
+
+    # Apples-to-apples block: the per-strategy metrics above each span that
+    # strategy's own history, which makes the columns incomparable.
+    matched_navs: dict[str, pd.Series] = {
+        "sp500": benchmark_nav,
+        "sp20_mirror": mirror_nav,
+        "sp20_equal": equal_nav,
+    }
+    if alpha_nav is not None:
+        matched_navs["spn_alpha"] = alpha_nav
+
+    matched = _matched_window_comparison(
+        matched_navs, benchmark_key="sp500", risk_free_rate=risk_free_rate
+    )
+    if matched:
+        payload["matched_window"] = matched
+        logger.info(
+            "Matched window %s -> %s (%.2fy); any comparison significant at "
+            "|t| > %.1f: %s",
+            matched["window"]["start"],
+            matched["window"]["end"],
+            matched["window"]["n_years"],
+            MULTIPLE_TESTING_T_HURDLE,
+            matched["any_significant"],
+        )
 
     return _write_json(payload, "performance_metrics.json")
 

--- a/scripts/export_frontend_data.py
+++ b/scripts/export_frontend_data.py
@@ -588,7 +588,11 @@ def _matched_window_comparison(
         block = compute_performance_metrics(
             nav, relative_to, risk_free_rate=risk_free_rate
         )
-        block.update(_compute_extra_metrics(nav, relative_to))
+        # Relative metrics (information ratio, Jensen alpha, beta) come from
+        # compute_performance_metrics alone — _compute_extra_metrics must not
+        # be handed the benchmark, or its dict `update` would silently override
+        # the canonical definitions with differently-derived ones.
+        block.update(_compute_extra_metrics(nav))
         block["window"] = _window_info(nav)
         metrics[key] = _clean_dict(block)
 

--- a/src/config.py
+++ b/src/config.py
@@ -75,6 +75,14 @@ DATA_START_DATE = date(2013, 1, 2)
 DEV_END = date(2023, 12, 31)
 HOLDOUT_START = date(2024, 1, 1)
 
+# Minimum |t| for an excess return to count as distinguishable from noise.
+# Harvey, Liu & Zhu (2016, RFS 29:1) show that after decades of data mining
+# across hundreds of published factors, the conventional t > 1.96 threshold is
+# invalid; a newly proposed cross-sectional predictor needs t > 3.0. Every
+# strategy-vs-benchmark claim this project makes is measured against that bar,
+# not against 1.96 — see the matched-window block in performance_metrics.json.
+MULTIPLE_TESTING_T_HURDLE = 3.0
+
 # ──────────────────────────────────────────────
 # Portfolio constraints
 # ──────────────────────────────────────────────

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -72,3 +72,132 @@ def test_drawdowns_truncate_at_last_real_datapoint(captured: dict[str, Any]) -> 
     payload = captured["drawdowns.json"]
     last_date = max(r["date"] for r in payload["weekly"])
     assert last_date == str(dates[89].date())
+
+
+# ──────────────────────────────────────────────────────────────
+# Matched-window comparison
+#
+# The per-strategy metric blocks each span that strategy's own history, so
+# reading them as columns of one table is not apples-to-apples. These guard
+# the block that fixes it — and, just as importantly, guard the significance
+# flag against silently degenerating to a constant.
+# ──────────────────────────────────────────────────────────────
+
+
+def test_matched_window_starts_at_first_shared_date() -> None:
+    """Baselines start earlier; the matched window must begin where all overlap."""
+    dates = pd.bdate_range("2020-01-01", periods=800)
+    navs = {
+        "sp500": _nav(dates, 0.0004, "sp500"),
+        "sp20_mirror": _nav(dates, 0.0005, "sp20_mirror"),
+        "sp20_equal": _nav(dates, 0.0005, "sp20_equal"),
+        # Walk-forward strategy only exists from day 300 onward.
+        "spn_alpha": _nav(dates[300:], 0.0006, "spn_alpha"),
+    }
+
+    matched = export._matched_window_comparison(navs)
+
+    assert matched["window"]["start"] == str(dates[300].date())
+    assert matched["window"]["end"] == str(dates[-1].date())
+
+
+def test_matched_window_reranks_total_return_fairly() -> None:
+    """A shorter, faster-compounding series must not lose on total return.
+
+    This is the exact defect the block exists to fix: measured over its own
+    longer window a slower series can post a larger total return purely by
+    having compounded for more years.
+    """
+    dates = pd.bdate_range("2020-01-01", periods=800)
+    # 800 days at 6bps/day compounds to ~1.62x; 500 days at 9bps/day to ~1.57x.
+    # The slower series leads on raw total return purely on window length.
+    slow_long = _nav(dates, 0.0006, "sp20_mirror")
+    fast_short = _nav(dates[300:], 0.0009, "spn_alpha")
+
+    # Unmatched, the slower series wins on raw total return...
+    assert slow_long.iloc[-1] / slow_long.iloc[0] > fast_short.iloc[-1] / fast_short.iloc[0]
+
+    matched = export._matched_window_comparison(
+        {
+            "sp500": _nav(dates, 0.0004, "sp500"),
+            "sp20_mirror": slow_long,
+            "sp20_equal": _nav(dates, 0.0005, "sp20_equal"),
+            "spn_alpha": fast_short,
+        }
+    )
+
+    # ...but on the shared window the faster compounder is correctly ahead.
+    assert (
+        matched["metrics"]["spn_alpha"]["total_return"]
+        > matched["metrics"]["sp20_mirror"]["total_return"]
+    )
+
+
+def test_matched_window_rebases_every_series_to_one() -> None:
+    dates = pd.bdate_range("2020-01-01", periods=800)
+    navs = {
+        "sp500": _nav(dates, 0.0004, "sp500") * 7.0,  # arbitrary starting level
+        "sp20_mirror": _nav(dates, 0.0005, "sp20_mirror"),
+        "sp20_equal": _nav(dates, 0.0005, "sp20_equal"),
+    }
+
+    matched = export._matched_window_comparison(navs)
+
+    # A pure scale factor must not change any return-based metric.
+    assert matched["metrics"]["sp500"]["cagr"] == pytest.approx(
+        (1.0004**252) - 1, rel=1e-3
+    )
+
+
+def test_matched_window_skipped_when_overlap_too_short() -> None:
+    """Under a year of overlap, report nothing rather than a noisy comparison."""
+    dates = pd.bdate_range("2024-01-01", periods=200)
+    navs = {
+        "sp500": _nav(dates, 0.0004, "sp500"),
+        "sp20_mirror": _nav(dates, 0.0005, "sp20_mirror"),
+        "sp20_equal": _nav(dates, 0.0005, "sp20_equal"),
+    }
+
+    assert export._matched_window_comparison(navs) == {}
+
+
+def test_active_return_stats_rejects_noise_dominated_edge() -> None:
+    """A small edge buried in noise must NOT clear the t > 3 hurdle."""
+    rng = np.random.default_rng(0)
+    dates = pd.bdate_range("2016-01-01", periods=2646)  # ~10.5y, as shipped
+    bench_returns = rng.normal(0.0005, 0.011, len(dates))
+    # +3bps/day of edge, swamped by 60bps/day of independent tracking noise.
+    strat_returns = bench_returns + 0.00003 + rng.normal(0, 0.006, len(dates))
+
+    benchmark = pd.Series(np.cumprod(1 + bench_returns), index=dates)
+    strategy = pd.Series(np.cumprod(1 + strat_returns), index=dates)
+
+    stats = export._active_return_stats(strategy, benchmark)
+
+    assert not stats["significant"]
+    assert abs(stats["t_stat"]) < 3.0
+    assert stats["years_for_hurdle"] is None or stats["years_for_hurdle"] > 10.5
+
+
+def test_active_return_stats_detects_a_genuine_edge() -> None:
+    """Guard against the flag degenerating to a constant False."""
+    rng = np.random.default_rng(1)
+    dates = pd.bdate_range("2016-01-01", periods=2646)
+    bench_returns = rng.normal(0.0005, 0.011, len(dates))
+    # Same edge, but with an order of magnitude less tracking noise.
+    strat_returns = bench_returns + 0.0004 + rng.normal(0, 0.0008, len(dates))
+
+    benchmark = pd.Series(np.cumprod(1 + bench_returns), index=dates)
+    strategy = pd.Series(np.cumprod(1 + strat_returns), index=dates)
+
+    stats = export._active_return_stats(strategy, benchmark)
+
+    assert stats["significant"]
+    assert stats["t_stat"] > 3.0
+    assert stats["years_for_hurdle"] is not None
+
+
+def test_active_return_stats_needs_enough_overlap() -> None:
+    dates = pd.bdate_range("2024-01-01", periods=20)
+    series = _nav(dates, 0.0005, "a")
+    assert export._active_return_stats(series, _nav(dates, 0.0004, "b")) == {}


### PR DESCRIPTION
## Why

The Performance Comparison table rendered columns measured over **different windows**. The baselines span 2014→now; SP-N Alpha only starts 2016, once its first walk-forward training window closes. The NAV chart already re-based everything to a common start — the table never did.

Three consequences, all misleading:

| | Before | After (matched) |
|---|---|---|
| Total Return leader | SP-20 Mirror 629.9% | **SP-N Alpha 598.2%** (Mirror 538.4%) |
| S&P 500 CAGR | 13.9% (a 2014 figure) | **15.4%** |
| Tracking Error "best" | S&P 500 @ 0.00% | benchmark excluded |

Mirror only led total return because it compounded for two extra years. And quoting the S&P's 2014 CAGR beside Alpha's 2016 CAGR overstated the gap by ~1.5pp.

## What changed

**Export** emits a `matched_window` block — every series re-based to the first date all four exist (2016-01-04, 10.5y), plus the pairwise significance of each active return.

**Table** prefers that block and falls back to the old per-strategy metrics when it is absent, so existing data bundles keep working. In fallback the header says the columns are not comparable and Total Return goes unranked.

**New `SignificancePanel`** states what a table of bold numbers cannot:

| Comparison | Active | TE | IR | t | Years to prove |
|---|---|---|---|---|---|
| SP-N Alpha vs S&P 500 | +4.80% | 7.94% | 0.60 | +1.96 | ~25 |
| SP-N Alpha vs SP-20 Equal | +2.88% | 6.13% | 0.47 | +1.52 | ~41 |
| SP-N Alpha vs SP-20 Mirror | +0.87% | 3.89% | 0.22 | +0.73 | **~178** |

Not one comparison clears the hurdle. The hurdle is `MULTIPLE_TESTING_T_HURDLE = 3.0` (Harvey, Liu & Zhu 2016) rather than 1.96, because 14 dev trials have been logged — it lives in `src/config.py`, not a component.

## Verification

- 121 pytest passed; 7 new tests cover window intersection, the total-return re-ranking, re-basing invariance, short-overlap bail-out, and **both** directions of the significance flag (a noise-dominated edge must fail, a genuine edge must pass — guards against the flag degenerating to a constant).
- ruff, mypy, eslint, `next build` all clean.
- Verified in-browser on both paths: with `matched_window` present (new table + panel) and absent (fallback, no crash, Total Return unranked).

## Not touched

`trials.jsonl`, `race_result.json`, and the holdout are untouched, and **no experiment was run** — every logged trial permanently inflates the deflated-Sharpe denominator, so that stays gated on explicit approval. Regenerated JSON is deliberately not committed; the daily cron owns `frontend/public/data`, and the panel appears after its next run.

## Follow-up worth deciding separately

SP-20 Mirror has **never** been a research reference — all 14 dev trials scored only against `^SP500TR` and `sp20_equal`. Any race targeting the Mirror needs it added to `references` with pre-registered criteria before candidate selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)